### PR TITLE
Temporary fix PMT#103497--replacing MEDIA_URL with partial S3 url

### DIFF
--- a/pass_app/templates/careermapblock/careermapblock.html
+++ b/pass_app/templates/careermapblock/careermapblock.html
@@ -36,9 +36,9 @@
         </h5>
         <select id="{{block.id}}-basemap-control" class="base_map_select" onchange="update_basemap (this)">
         {% for basemap in block.basemap_set.all %}
-        <option basemap_id="{{basemap.id}}" value="{{MEDIA_URL}}{{ basemap.image }}">{{basemap.name}}</option>
+        <option basemap_id="{{basemap.id}}" value="https://ccnmtl-pass-static-prod.s3.amazonaws.com/uploads/{{ basemap.image }}">{{basemap.name}}</option>
         {% endfor %}
-        </select><br />
+        </select><br /><br />
         <h5>
         Show layers:
         </h5>
@@ -81,10 +81,10 @@
 
 <td id = "right_hand_td">
             <div id="{{block.id}}-base" class="careermap-base">
-                <img class="basemap_image"  id="{{block.id}}-basemap" alt="career map" src="{{MEDIA_URL}}{{ block.default_base_map.image}}"/>
+                <img class="basemap_image"  id="{{block.id}}-basemap" alt="career map" src="https://ccnmtl-pass-static-prod.s3.amazonaws.com/uploads/{{ block.default_base_map.image}}"/>
                 <!-- These are the layers that you can show and hide and show up on the list of layers. -->
                 {% for layer in block.layer_set.all %}
-                <img id="layer-{{layer.id}}" src="{{MEDIA_URL}}{{layer.image}}"
+                <img id="layer-{{layer.id}}" src="https://ccnmtl-pass-static-prod.s3.amazonaws.com/uploads/{{layer.image}}"
                      class="careermap-layer show_and_hideable" />
                 {% endfor %}
 


### PR DESCRIPTION
replaced MEDIA_URL with part of S3 url to temporarily fix the missing image layers in career map block for Young Children module (Advise Sally and Your Selections). A separate PMT has been created to address the underlying issue to this problem https://pmt.ccnmtl.columbia.edu/item/104795/